### PR TITLE
Support deserializing deeply nested sequences

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde-redis"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Joe Wilm <joe@jwilm.com>"]
 description = "Serde deserialization for redis-rs"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
It's possible for some Redis calls to return deeply nested sequneces
(eg. from a Lua script). This adds support for deserializing things with
arbitrary nesting.

Supporting arbitrary nesting resulted in a simplified design for
deserializer. To deserialize a nested sequence, we recurse into an
additional Deserializer. This contrasts with the previous design which
maintained additional state within a single deserializer. Furthermore,
no more Vec::reverse is needed; a peekable iterator is used instead.

To keep compatibility with the old API, a trait was added `IntoValueVec`
which is implemented for redis::Value and Vec<redis::Value>.