### PR TITLE
Implement deserializing structs which contain structs, sets, or lists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 target
 Cargo.lock
+.idea/
+CMakeLists.txt
+cmake-build-debug/

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -7,7 +7,7 @@ use std::vec;
 use std::str::from_utf8;
 use std::error::Error as StdError;
 
-use redis::{self, Value, Commands};
+use redis::{self, Value};
 
 use serde::{self, de};
 use serde::de::Error as SerdeError;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,10 +16,18 @@ pub fn from_redis_value<'de, T>(rv: ::redis::Value) -> decode::Result<T>
     ::serde::de::Deserialize::deserialize(Deserializer::new(rv))
 }
 
+/// Use serde Deserialize to build `T` from a `redis::Value` with support for deep links
+pub fn from_redis_value_deep<'de, T>(rv: ::redis::Value, db: &'de redis::Connection) -> decode::Result<T>
+    where T: serde::de::Deserialize<'de>
+{
+    ::serde::de::Deserialize::deserialize(Deserializer::new_deep(rv, db))
+}
+
 pub trait RedisDeserialize<'de, T>
     where T: serde::de::Deserialize<'de>
 {
     fn deserialize(self) -> decode::Result<T>;
+    fn deserialize_deep(self, db: &'de redis::Connection) -> decode::Result<T>;
 }
 
 impl<'de, T> RedisDeserialize<'de, T> for redis::Value
@@ -27,6 +35,10 @@ impl<'de, T> RedisDeserialize<'de, T> for redis::Value
 {
     fn deserialize(self) -> decode::Result<T> {
         ::serde::de::Deserialize::deserialize(Deserializer::new(self))
+    }
+
+    fn deserialize_deep(self, db: &'de redis::Connection) -> decode::Result<T> {
+        ::serde::de::Deserialize::deserialize(Deserializer::new_deep(self, db))
     }
 }
 


### PR DESCRIPTION
This allows structs, such as `Location` in this example, to be deserialized successfully:
```rust
struct Location {
    name: String,
    coord: Coordinate
}

struct Coordinate {
    x: i32,
    y: i32
}
```
In Redis, an instance of these structs might look like this:
```
> HMSET location:0 name "location_name" coord "coord:0"
> HMSET coord:0 x 0 y 0
---------------------------
location:0
    name => "location_name"
    coord => "coord:0"

coord:0
    x => 0
    y => 0
```

The jump between `coord` on `location:0` to the values of `coord:0` is not taken by the current deserializer. This is a common pattern to link related sets of data and get around the lack of inner hashes.

However, there is good reason to avoid this feature. This will cause a stack overflow if there is a circular reference. This should be fixed before it is merged. It is common to have a circular relation, as an `Album` might have an `Artist` who has a list of `Album`s who have their own `Artist`s, one of which is the original.

I haven't added tests yet. It might be possible to mock out a struct which implements enough traits to act like a real connection, perhaps by using `redis::ConnectionLike`.