### PR TITLE
Fix bool decoding

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -274,9 +274,23 @@ impl<'de> serde::Deserializer<'de> for Deserializer {
     default_deserialize!(
         deserialize_str
         deserialize_char
-        deserialize_bool
         deserialize_unit
     );
+
+    #[inline]
+    fn deserialize_bool<V>(mut self, visitor: V) -> Result<V::Value>
+        where V: de::Visitor<'de>,
+    {
+        let s = self.read_string()?;
+
+        let b = match s.as_str() {
+            "1" | "true" | "True" => true,
+            "0" | "false" | "False" => false,
+            _ => return Err(Error::WrongValue(format!("Expected 1/0/true/false/True/False, got {}", s)))
+        };
+
+        visitor.visit_bool(b)
+    }
 
     #[inline]
     fn deserialize_bytes<V>(self, visitor: V) -> Result<V::Value>

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -55,8 +55,8 @@ fn deserialize_bool() {
     let de = Deserializer::new(Value::Bulk(v));
     let actual: Vec<bool> = Deserialize::deserialize(de).unwrap();
 
-    let expected = vec![false, false, false, true, true, true];
-    assert_eq!(expected, actual);
+    let expected = [false, false, false, true, true, true];
+    assert_eq!(&expected, &actual[..]);
 }
 
 #[test]

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -46,6 +46,20 @@ fn deserialize_unit_struct_u8_redis_int() {
 }
 
 #[test]
+fn deserialize_bool() {
+    let v = vec![
+        Value::Data(b"0".to_vec()), Value::Data(b"false".to_vec()), Value::Data(b"False".to_vec()),
+        Value::Data(b"1".to_vec()), Value::Data(b"true".to_vec()), Value::Data(b"True".to_vec())
+    ];
+
+    let de = Deserializer::new(Value::Bulk(v));
+    let actual: Vec<bool> = Deserialize::deserialize(de).unwrap();
+
+    let expected = vec![false, false, false, true, true, true];
+    assert_eq!(expected, actual);
+}
+
+#[test]
 fn deserialize_tuple() {
     let v = vec![Value::Int(5), Value::Data(b"hello".to_vec())];
 


### PR DESCRIPTION
Unless I'm mistaken, `bool`s can't be decoded at the moment 😱

This adds support for decoding `bool`s from their regular string incarnations: `"0"`, `"1"`, `"false"`, `"true"`, `"False"`, and `"True"`.

Also included is a test to ensure that `bool`s stay deserializable.