### PR TITLE
Allow library to support redis 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde-redis"
-version = "0.7.2"
+version = "0.7.3"
 authors = ["Joe Wilm <joe@jwilm.com>"]
 description = "Serde deserialization for redis-rs"
 license = "MIT OR Apache-2.0"
@@ -9,7 +9,7 @@ repository = "https://github.com/OneSignal/serde-redis"
 documentation = "https://OneSignal.github.io/serde-redis/serde_redis/"
 
 [dependencies]
-redis = "> 0.5, < 0.9"
+redis = "> 0.5, <= 0.9"
 serde = "1.0"
 
 [dev-dependencies]


### PR DESCRIPTION
The Redis::value type did not change between redis 0.8 and redis 0.9,
and we need to use this library in conjunction with redis 0.9.