### PR TITLE
Re-add deserialize_any support

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -23,7 +23,6 @@ pub enum Error {
     FromUtf8(string::FromUtf8Error),
     ParseInt(num::ParseIntError),
     ParseFloat(num::ParseFloatError),
-    AnyUnsupported,
 }
 
 impl Error {
@@ -51,7 +50,6 @@ impl error::Error for Error {
             Error::FromUtf8(ref err) => err.description(),
             Error::ParseInt(ref err) => err.description(),
             Error::ParseFloat(ref err) => err.description(),
-            Error::AnyUnsupported => "Deserializer::deserialize_any is unsupported",
         }
     }
 
@@ -85,10 +83,6 @@ impl fmt::Display for Error {
             Error::FromUtf8(ref e) => write!(f, "{}", e),
             Error::ParseInt(ref e) => write!(f, "{}", e),
             Error::ParseFloat(ref e) => write!(f, "{}", e),
-            Error::AnyUnsupported => write!(
-                f,
-                "Tried to deserialize using serde::deserialize_any, which is not supported"
-            ),
         }
     }
 }
@@ -263,11 +257,12 @@ impl<'de> serde::Deserializer<'de> for Deserializer {
     type Error = Error;
 
     #[inline]
-    fn deserialize_any<V>(self, _visitor: V) -> Result<V::Value>
+    fn deserialize_any<V>(mut self, visitor: V) -> Result<V::Value>
     where
         V: de::Visitor<'de>,
     {
-        Err(Error::AnyUnsupported)
+        let buf = self.next_bytes()?;
+        visitor.visit_byte_buf(buf)
     }
 
     #[inline]

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -9,7 +9,7 @@ extern crate serde_redis;
 use std::collections::HashMap;
 
 use serde::Deserialize;
-use serde_redis::{from_redis_value, Deserializer};
+use serde_redis::Deserializer;
 
 use redis::Value;
 


### PR DESCRIPTION
Many users depend on this existing behavior of assuming a parse_any is
a string. I should not have removed it.