### PR TITLE
Support for taking borrowed values / 0.8.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
-Changes
-=======
+# Changes
+
+## 0.8.0
+
+- Support for borrowing the value passed to deserialization functions
 
 ## 0.7.2
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "serde-redis"
-version = "0.7.3"
+version = "0.8.0"
 authors = ["Joe Wilm <joe@jwilm.com>"]
 description = "Serde deserialization for redis-rs"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/OneSignal/serde-redis"
-documentation = "https://OneSignal.github.io/serde-redis/serde_redis/"
+documentation = "https://docs.rs/serde-redis"
 edition = "2018"
 
 [dependencies]

--- a/src/cow_iter.rs
+++ b/src/cow_iter.rs
@@ -1,0 +1,30 @@
+use redis::Value;
+use std::borrow::Cow;
+use std::{slice, vec};
+
+/// An iterator that can iterate over borrowed or owned values from a borrowed or
+/// owned vec
+pub enum CowIter<'a> {
+    Borrowed(slice::Iter<'a, Value>),
+    Owned(vec::IntoIter<Value>),
+}
+
+impl<'a> CowIter<'a> {
+    pub fn new(values: impl Into<Cow<'a, Vec<Value>>>) -> Self {
+        match values.into() {
+            Cow::Borrowed(values) => CowIter::Borrowed(values.iter()),
+            Cow::Owned(values) => CowIter::Owned(values.into_iter()),
+        }
+    }
+}
+
+impl<'a> Iterator for CowIter<'a> {
+    type Item = Cow<'a, Value>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            CowIter::Borrowed(iter) => iter.next().map(Cow::Borrowed),
+            CowIter::Owned(iter) => iter.next().map(Cow::Owned),
+        }
+    }
+}

--- a/src/into_cow.rs
+++ b/src/into_cow.rs
@@ -1,0 +1,22 @@
+use redis::Value;
+use std::borrow::Cow;
+
+/// A value that can be turned into a `Cow<'a, Value>`. This is primarily useful
+/// because there is not an `impl Into<Cow<'a, Value>>` built-in for
+/// `redis::Value` and `&'a redis::Value`. This allows `from_redis_value` to take
+/// either one of those.
+pub trait IntoCow<'a> {
+    fn into_cow(self) -> Cow<'a, Value>;
+}
+
+impl<'a> IntoCow<'a> for &'a Value {
+    fn into_cow(self) -> Cow<'a, Value> {
+        Cow::Borrowed(self)
+    }
+}
+
+impl IntoCow<'static> for Value {
+    fn into_cow(self) -> Cow<'static, Value> {
+        Cow::Owned(self)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,20 +1,21 @@
-use std::borrow::Borrow;
-
 // `encode` and `decode` are used instead of `ser` and `de` to avoid confusion with the serder
 // Serializer and Deserializer traits which occupy a similar namespace.
+mod cow_iter;
 pub mod decode;
 pub mod encode;
+mod into_cow;
 
 pub use crate::decode::Deserializer;
 pub use crate::encode::Serializer;
+pub use crate::into_cow::IntoCow;
 
 /// Use serde Deserialize to build `T` from a `redis::Value`
 pub fn from_redis_value<'de, T, RV>(rv: RV) -> decode::Result<T>
 where
     T: serde::de::Deserialize<'de>,
-    RV: Borrow<redis::Value>,
+    RV: IntoCow<'de>,
 {
-    let value = rv.borrow();
+    let value = rv.into_cow();
     serde::de::Deserialize::deserialize(Deserializer::new(value))
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+use std::borrow::Borrow;
+
 // `encode` and `decode` are used instead of `ser` and `de` to avoid confusion with the serder
 // Serializer and Deserializer traits which occupy a similar namespace.
 pub mod decode;
@@ -7,25 +9,27 @@ pub use crate::decode::Deserializer;
 pub use crate::encode::Serializer;
 
 /// Use serde Deserialize to build `T` from a `redis::Value`
-pub fn from_redis_value<'de, T>(rv: redis::Value) -> decode::Result<T>
+pub fn from_redis_value<'de, T, RV>(rv: RV) -> decode::Result<T>
 where
     T: serde::de::Deserialize<'de>,
+    RV: Borrow<redis::Value>,
 {
-    serde::de::Deserialize::deserialize(Deserializer::new(rv))
+    let value = rv.borrow();
+    serde::de::Deserialize::deserialize(Deserializer::new(value))
 }
 
 pub trait RedisDeserialize<'de, T>
 where
     T: serde::de::Deserialize<'de>,
 {
-    fn deserialize(self) -> decode::Result<T>;
+    fn deserialize(&'de self) -> decode::Result<T>;
 }
 
 impl<'de, T> RedisDeserialize<'de, T> for redis::Value
 where
     T: serde::de::Deserialize<'de>,
 {
-    fn deserialize(self) -> decode::Result<T> {
+    fn deserialize(&'de self) -> decode::Result<T> {
         serde::de::Deserialize::deserialize(Deserializer::new(self))
     }
 }
@@ -46,10 +50,20 @@ mod tests {
     }
 
     #[test]
-    fn from_redis_value_works() {
+    fn from_redis_value_works_with_owned() {
         let v = Value::Bulk(vec![Value::Int(5), Value::Data(b"hello".to_vec())]);
 
         let actual: (u8, String) = from_redis_value(v).unwrap();
+        let expected = (5, "hello".into());
+
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn from_redis_value_works_with_borrow() {
+        let v = Value::Bulk(vec![Value::Int(5), Value::Data(b"hello".to_vec())]);
+
+        let actual: (u8, String) = from_redis_value(&v).unwrap();
         let expected = (5, "hello".into());
 
         assert_eq!(expected, actual);

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -20,7 +20,7 @@ fn deserialize_unit_struct_string() {
     #[derive(Deserialize, Debug, PartialEq)]
     struct Unit(String);
 
-    let de = Deserializer::new(v);
+    let de = Deserializer::new(&v);
     let actual: Unit = Deserialize::deserialize(de).unwrap();
 
     let expected = Unit("hello".to_owned());
@@ -35,7 +35,7 @@ fn deserialize_unit_struct_u8_redis_int() {
     #[derive(Deserialize, Debug, PartialEq)]
     struct IntUnit(u8);
 
-    let de = Deserializer::new(v);
+    let de = Deserializer::new(&v);
     let actual: IntUnit = Deserialize::deserialize(de).unwrap();
 
     let expected = IntUnit(num);
@@ -53,7 +53,9 @@ fn deserialize_bool() {
         Value::Data(b"True".to_vec()),
     ];
 
-    let de = Deserializer::new(Value::Bulk(v));
+    let data = Value::Bulk(v);
+
+    let de = Deserializer::new(&data);
     let actual: Vec<bool> = Deserialize::deserialize(de).unwrap();
 
     let expected = [false, false, false, true, true, true];
@@ -64,7 +66,9 @@ fn deserialize_bool() {
 fn deserialize_tuple() {
     let v = vec![Value::Int(5), Value::Data(b"hello".to_vec())];
 
-    let de = Deserializer::new(Value::Bulk(v));
+    let data = Value::Bulk(v);
+
+    let de = Deserializer::new(&data);
     let actual: (u8, String) = Deserialize::deserialize(de).unwrap();
 
     let expected = (5, "hello".to_owned());
@@ -86,7 +90,9 @@ fn deserialize_struct() {
         b: String,
     }
 
-    let de = Deserializer::new(Value::Bulk(v));
+    let data = Value::Bulk(v);
+
+    let de = Deserializer::new(&data);
     let actual: Simple = Deserialize::deserialize(de).unwrap();
 
     let expected = Simple {
@@ -110,7 +116,9 @@ fn deserialize_hash_map_strings() {
     expected.insert("a".to_string(), "apple".to_string());
     expected.insert("b".to_string(), "banana".to_string());
 
-    let de = Deserializer::new(Value::Bulk(v));
+    let data = Value::Bulk(v);
+
+    let de = Deserializer::new(&data);
     let actual: HashMap<String, String> = Deserialize::deserialize(de).unwrap();
 
     assert_eq!(expected, actual);
@@ -122,7 +130,7 @@ fn deserialize_float() {
 
     let expected = "3.14159".parse::<f32>().unwrap();
 
-    let de = Deserializer::new(v);
+    let de = Deserializer::new(&v);
     let actual: f32 = Deserialize::deserialize(de).unwrap();
 
     assert_eq!(actual, expected);
@@ -141,7 +149,9 @@ fn deserialize_hash_map_string_u8() {
     expected.insert("a".to_string(), 1);
     expected.insert("b".to_string(), 2);
 
-    let de = Deserializer::new(Value::Bulk(v));
+    let data = Value::Bulk(v);
+
+    let de = Deserializer::new(&data);
     let actual: HashMap<String, u8> = Deserialize::deserialize(de).unwrap();
 
     assert_eq!(expected, actual);
@@ -162,7 +172,9 @@ fn deserialize_struct_out_of_order() {
         b: String,
     }
 
-    let de = Deserializer::new(Value::Bulk(v));
+    let data = Value::Bulk(v);
+
+    let de = Deserializer::new(&data);
     let actual: Simple = Deserialize::deserialize(de).unwrap();
 
     let expected = Simple {
@@ -190,7 +202,9 @@ fn deserialize_struct_extra_keys() {
         b: String,
     }
 
-    let de = Deserializer::new(Value::Bulk(v));
+    let data = Value::Bulk(v);
+
+    let de = Deserializer::new(&data);
     let actual: Simple = Deserialize::deserialize(de).unwrap();
 
     let expected = Simple {
@@ -211,7 +225,7 @@ fn deserialize_enum() {
         Apple,
     }
 
-    let de = Deserializer::new(v);
+    let de = Deserializer::new(&v);
     let actual: Fruit = Deserialize::deserialize(de).unwrap();
 
     assert_eq!(Fruit::Orange, actual);
@@ -219,7 +233,7 @@ fn deserialize_enum() {
 
 #[test]
 fn deserialize_option() {
-    let de = Deserializer::new(Value::Nil);
+    let de = Deserializer::new(&Value::Nil);
     let actual: Option<u8> = Deserialize::deserialize(de).unwrap();
 
     assert_eq!(None, actual);
@@ -251,7 +265,9 @@ fn deserialize_complex_struct() {
         s: "yarn".to_owned(),
     };
 
-    let de = Deserializer::new(Value::Bulk(v));
+    let data = Value::Bulk(v);
+
+    let de = Deserializer::new(&data);
     let actual: Complex = Deserialize::deserialize(de).unwrap();
 
     assert_eq!(expected, actual);
@@ -265,7 +281,9 @@ fn deserialize_vec_of_strings() {
         Value::Data(b"third".to_vec()),
     ];
 
-    let de = Deserializer::new(Value::Bulk(v));
+    let data = Value::Bulk(v);
+
+    let de = Deserializer::new(&data);
     let actual: Vec<String> = Deserialize::deserialize(de).unwrap();
 
     let expected = vec![
@@ -287,7 +305,9 @@ fn deserialize_vec_of_newtype() {
     #[derive(Debug, PartialEq, Deserialize)]
     struct Rank(String);
 
-    let de = Deserializer::new(Value::Bulk(v));
+    let data = Value::Bulk(v);
+
+    let de = Deserializer::new(&data);
     let actual: Vec<Rank> = Deserialize::deserialize(de).unwrap();
 
     let expected = vec![
@@ -326,7 +346,7 @@ fn deserialize_pipelined_hmap() {
         b: String,
     }
 
-    let de = Deserializer::new(values);
+    let de = Deserializer::new(&values);
     let actual: Vec<Simple> = Deserialize::deserialize(de).unwrap();
 
     let expected = vec![
@@ -358,7 +378,7 @@ fn deserialize_pipelined_single_hmap() {
         b: String,
     }
 
-    let de = Deserializer::new(values);
+    let de = Deserializer::new(&values);
     let actual: Vec<Simple> = Deserialize::deserialize(de).unwrap();
 
     let expected = vec![Simple {
@@ -387,7 +407,9 @@ fn deserialize_struct_with_newtype_field() {
         b: Fruit,
     }
 
-    let de = Deserializer::new(Value::Bulk(v));
+    let data = Value::Bulk(v);
+
+    let de = Deserializer::new(&data);
     let actual: Simple = Deserialize::deserialize(de).unwrap();
 
     let expected = Simple {
@@ -400,7 +422,8 @@ fn deserialize_struct_with_newtype_field() {
 
 #[test]
 fn deserialize_byte_buf() {
-    let de = Deserializer::new(Value::Data(b"0000".to_vec()));
+    let data = Value::Data(b"0000".to_vec());
+    let de = Deserializer::new(&data);
     let actual: serde_bytes::ByteBuf = Deserialize::deserialize(de).unwrap();
 
     let expected = b"0000";
@@ -425,7 +448,7 @@ fn deserialize_pipelined_single_hmap_newtype_fields() {
         b: Fruit,
     }
 
-    let de = Deserializer::new(values);
+    let de = Deserializer::new(&values);
     let actual: Vec<Simple> = Deserialize::deserialize(de).unwrap();
 
     let expected = vec![Simple {
@@ -463,7 +486,7 @@ fn deserialize_nested_map_map_list() {
         ]),
     ]);
 
-    let de = Deserializer::new(value);
+    let de = Deserializer::new(&value);
     let map: MapMapList = Deserialize::deserialize(de).unwrap();
 
     let nest = map.get("key").unwrap();
@@ -484,6 +507,6 @@ fn deserialize_nested_map_map_list() {
 fn deserialize_nested_item() {
     let value = Value::Bulk(vec![Value::Bulk(vec![Value::Data(b"hi".to_vec())])]);
 
-    let de = Deserializer::new(value);
+    let de = Deserializer::new(&value);
     let _hellos: Vec<String> = Deserialize::deserialize(de).unwrap();
 }


### PR DESCRIPTION
Borrowed values should be accepted in the deserialize functions in case
we want to use the values after being deserialized.

Since I used the `Borrow` trait in the definition of `from_redis_value`, this should not be a breaking change, as you should still be able to pass an owned value into this function.

