### PR TITLE
Add support for parsing  `HashMap<String, Value>` for Redis Stream read commands

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/serde-redis"
 edition = "2018"
 
 [dependencies]
-redis = "0.22.3"
+redis= "0.23.3"
 serde = "1.0"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,14 @@ where
     serde::de::Deserialize::deserialize(Deserializer::new(value))
 }
 
+/// Use serde Deserialize to build `T` from a `HashMap<String, redis::Value>`
+pub fn from_hashmap_value<'de, T>(rv: &'de  HashMap<String, redis::Value>) -> decode::Result<T>
+where
+    T: serde::de::Deserialize<'de>,
+{
+    RedisDeserialize::deserialize(rv)
+}
+
 pub trait RedisDeserialize<'de, T>
 where
     T: serde::de::Deserialize<'de>,

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -510,3 +510,29 @@ fn deserialize_nested_item() {
     let de = Deserializer::new(&value);
     let _hellos: Vec<String> = Deserialize::deserialize(de).unwrap();
 }
+
+#[test]
+fn deserialize_values_wrapped_in_hashmap() {
+    use serde_redis::RedisDeserialize;
+
+    let mut data = HashMap::new();
+
+    data.insert("a".to_string(),Value::Data(b"apple".to_vec()));
+    data.insert("b".to_string(),Value::Data(b"banana".to_vec()));
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct Simple {
+        a: String,
+        b: String,
+    }
+
+    let actual: Simple =  data.deserialize().unwrap();
+
+    let expected = Simple {
+        a: "apple".to_owned(),
+        b: "banana".to_owned(),
+    };
+
+    assert_eq!(expected, actual);
+}
+

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -535,4 +535,3 @@ fn deserialize_values_wrapped_in_hashmap() {
 
     assert_eq!(expected, actual);
 }
-


### PR DESCRIPTION
Support to deserialize `HashMap<String, Value>` received from redis streams commands XREAD and XGROUPREAD by adding `RedisDeserialize` trait for and function `from_hashmap_value`

Addresses XREAD, and XGROUPREAD commands for https://github.com/OneSignal/serde-redis/issues/31